### PR TITLE
Set project indent setting to 2 spaces.

### DIFF
--- a/SousChef/SousChef.xcodeproj/project.pbxproj
+++ b/SousChef/SousChef.xcodeproj/project.pbxproj
@@ -249,7 +249,9 @@
 				299567661A268A2A006EE6EE /* Frameworks */,
 				294B75F91A24173300BBCE01 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		294B75F91A24173300BBCE01 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
@rnystrom this should enable all source files to have an indent of 2 spaces instead of 4.