### PR TITLE
Remove foundation import for consistency.

### DIFF
--- a/SousChef/RW Recipes WatchKit Extension/GroceryRowController.swift
+++ b/SousChef/RW Recipes WatchKit Extension/GroceryRowController.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Ray Wenderlich. All rights reserved.
 //
 
-import Foundation
 import WatchKit
 
 class GroceryRowController: NSObject {

--- a/SousChef/RW Recipes WatchKit Extension/GroceryTypeController.swift
+++ b/SousChef/RW Recipes WatchKit Extension/GroceryTypeController.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Ray Wenderlich. All rights reserved.
 //
 
-import Foundation
 import WatchKit
 
 class GroceryTypeController: NSObject {

--- a/SousChef/RW Recipes WatchKit Extension/RecipeRowController.swift
+++ b/SousChef/RW Recipes WatchKit Extension/RecipeRowController.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Ray Wenderlich. All rights reserved.
 //
 
-import Foundation
 import WatchKit
 
 class RecipeRowController: NSObject {


### PR DESCRIPTION
@rnystrom some of the row controllers, such as `StepRowController` don't import foundation, only WatchKit. This PR makes all row controllers consistent.